### PR TITLE
Second CAE with inputs and outputs restricted to [-1, 1]

### DIFF
--- a/ibd_ae.py
+++ b/ibd_ae.py
@@ -12,7 +12,7 @@ from matplotlib import pyplot as plt
 from sklearn.decomposition import PCA
 from vis.viz import Viz
 from util.data_loaders import load_ibd_pairs, get_ibd_data
-from networks.LasagneConv import IBDPairConvAe
+from networks.LasagneConv import IBDPairConvAe, IBDPairConvAe2
 import argparse
 import logging
 logging.basicConfig(format='%(levelname)s:\t%(message)s')
@@ -40,6 +40,12 @@ def setup_parser():
         help='optionally save AE prediction to specified h5 file')
     parser.add_argument('-l', '--learn_rate', default=0.001, type=float,
         help='the learning rate for the network')
+    parser.add_argument('--network', default='IBDPairConvAe',
+        choices=[
+            'IBDPairConvAe',
+            'IBDPairConvAe2',
+        ],
+        help='network to use')
     return parser
 
 if __name__ == "__main__":
@@ -47,8 +53,9 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     #class for networks architecture
-    logging.info('Constructing untrained ConvNet')
-    cae = IBDPairConvAe(bottleneck_width=args.bottleneck_width,
+    logging.info('Constructing untrained ConvNet of class %s', args.network)
+    convnet_class = eval(args.network)
+    cae = convnet_class(bottleneck_width=args.bottleneck_width,
         epochs=args.epochs, learn_rate=args.learn_rate)
     logging.info('Preprocessing data files')
     train, val, test = get_ibd_data(tot_num_pairs=args.numpairs)

--- a/networks/LasagneConv.py
+++ b/networks/LasagneConv.py
@@ -7,7 +7,6 @@ import lasagne as l
 from operator import mul
 import logging
 logging.getLogger().setLevel(logging.DEBUG)
-from overrides import overrides
 
 from Network import AbstractNetwork
 import preprocessing
@@ -206,7 +205,6 @@ class IBDPairConvAe2(IBDPairConvAe):
         '''Initialize an IBDPairConvAe2.'''
         super(IBDPairConvAe2, self).__init__(*args, **kwargs)
 
-    @overrides
     def _setup_network(self):
         '''Set up the IBDPairConvAe network but have it scale output to +/- 1'''
         network = super(IBDPairConvAe2, self)._setup_network()
@@ -214,7 +212,6 @@ class IBDPairConvAe2(IBDPairConvAe):
         network.nonlinearity = l.nonlinearities.tanh
         return network
 
-    @overrides
     def preprocess_data(self, x, y=None):
         '''Prepare the data for the neural network.
 

--- a/networks/LasagneConv.py
+++ b/networks/LasagneConv.py
@@ -7,6 +7,7 @@ import lasagne as l
 from operator import mul
 import logging
 logging.getLogger().setLevel(logging.DEBUG)
+from overrides import overrides
 
 from Network import AbstractNetwork
 import preprocessing
@@ -195,4 +196,40 @@ class IBDPairConvAe(AbstractNetwork):
             preprocessing.fix_time_zeros(other)
             other -= means
             other /= stds/std
+        return repeat_transformation
+
+
+class IBDPairConvAe2(IBDPairConvAe):
+    '''A CAE based on IBDPairConvAe that scales input and output to be between
+       [-1, 1].'''
+    def __init__(self, *args, **kwargs):
+        '''Initialize an IBDPairConvAe2.'''
+        super(IBDPairConvAe2, self).__init__(*args, **kwargs)
+
+    @overrides
+    def _setup_network(self):
+        '''Set up the IBDPairConvAe network but have it scale output to +/- 1'''
+        network = super(IBDPairConvAe2, self)._setup_network()
+        # The "network" is really a pointer to the output deconv layer
+        network.nonlinearity = l.nonlinearities.tanh
+        return network
+
+    @overrides
+    def preprocess_data(self, x, y=None):
+        '''Prepare the data for the neural network.
+
+            - Remove 0's from the time channels
+            - Center the data on 0
+            - Scale it to have lie on the interval [-1, 1]'''
+        preprocessing.fix_time_zeros(x)
+        means = preprocessing.center(x)
+        min_, max_, = -1, 1
+        mins, maxes = preprocessing.scale_min_max(x, min_, max_)
+        def repeat_transformation(other):
+            preprocessing.fix_time_zeros(other)
+            other -= means
+            other -= mins
+            other /= maxes - mins
+            other *= max_ - min_
+            other += min_
         return repeat_transformation

--- a/networks/README.md
+++ b/networks/README.md
@@ -59,3 +59,21 @@ performed, etc.
         - 4 filters
         - (2, 4) filter size
         - (2, 2) stride
+
+IBDPairConvAe2
+-----------
+
+This convolutional autoencoder is based on
+[IBDPairConvAe](https://github.com/NERSC/dayabay-learn/tree/master/networks#ibdpairconvae).
+It is identical in all respects except for the preprocessing and final
+deconvolutional layer.
+
+ - File:
+[LasagneConv.py](https://github.com/NERSC/dayabay-learn/blob/master/networks/LasagneConv.py)
+
+ - Preprocessing changes:
+    - Divide each channel by a constant (common over events) so that each
+      channel's minimum pixel has value -1 and each channel's maximum has value
+      +1. This is instead of rescaling so that the standard deviation is 1.
+ - Final deconvolutional layer changes:
+    - Tanh activation

--- a/vis/examine.py
+++ b/vis/examine.py
@@ -8,72 +8,9 @@ import os
 import logging
 logging.getLogger().setLevel(logging.DEBUG)
 sys.path.append(os.path.abspath('../util'))
+sys.path.append(os.path.abspath('../networks'))
 from data_loaders import load_ibd_pairs, load_predictions
-from helper_fxns import center, scale
-
-def channelNeighbors(points, full, axes=(2, 3), condition=lambda x:True,
-        stillbad = None):
-    '''Create a list of orthogonal neighbors of each point that satisfy the given
-    condition.
-
-    return_val[i] = [(neighbor 1 index), (neighbor 2 index), ...] for points[i]
-
-    Axes specifies the directions to explore for neighbors. For example,
-    specifying axes=(2, 3) will hold the first 2 indices constant and only
-    adjust the 2nd and 3rd indices.
-
-    Condition is a function of the potential neighbor. For example it can test
-    if the neighbor is nonzero. Any neighbor for which the condition returns
-    True is included.
-    
-    Stillbad is an optional list to hold point indices that have no neighbors
-    satisfying condition. If provided, it should be specified as an empty list.'''
-    # adjust the condition to apply to the data at an index rather than at the
-    # index itself (as filter() would normally assume)
-    condition_full = lambda x:condition(full[x])
-    shape = full.shape
-    all_neighbors = []
-    for point in points:
-        point_neighbors = []
-        for axis in axes:
-            test_point_low = np.asarray(point)
-            test_point_up = test_point_low.copy()
-            if test_point_low[axis] > 0:
-                test_point_low[axis] -= 1
-                point_neighbors.append(tuple(test_point_low))
-            if test_point_up[axis] < shape[axis] - 1:
-                test_point_up[axis] += 1
-                point_neighbors.append(tuple(test_point_up))
-        good_neighbors = filter(condition_full, point_neighbors)
-        if len(good_neighbors) == 0:
-            if stillbad is not None:
-                stillbad.append(point)
-        all_neighbors.append(good_neighbors)
-    return all_neighbors
-
-def smearTimeZeros(data):
-    bads = zip(*np.nonzero(data == 0))
-    # Only take the time channels (not the charge channels)
-    bads = filter(lambda x:x[1] in (1, 3), bads)
-
-
-    # Get list of neighbors for each point
-    # [[point 0 neighbors], [point 1 neighbors], ...]
-    stillbad = []
-    neighbors = channelNeighbors(bads, data, axes=(2, 3),
-        condition=lambda x:x < 0, stillbad=stillbad)
-    replacements = np.hstack(np.mean(data[zip(*ns)]) if len(ns) > 0 else 0 for ns in neighbors)
-    data[zip(*bads)] = replacements
-    iterations = 0
-    while len(stillbad) > 0 and iterations < 3:
-        iterations += 1
-        bads = stillbad
-        stillbad = []
-        neighbors = channelNeighbors(bads, data, axes=(2, 3),
-            condition=lambda x:x < 0, stillbad=stillbad)
-        replacements = np.hstack(np.mean(data[zip(*ns)]) if len(ns) > 0 else 0 for ns in neighbors)
-        data[zip(*bads)] = replacements
-
+from LasagneConv import IBDPairConvAe, IBDPairConvAe2
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
@@ -85,28 +22,28 @@ if __name__ == '__main__':
         help='interpret the file as input')
     gp.add_argument('-o', '--output', action='store_true',
         help='interpret the file as output')
-    parser.add_argument('--no-preprocess', action='store_true',
-        help='turn off data centering and scaling')
-    parser.add_argument('--no-fix-zeros', action='store_true',
-        help='turn of zero replacement')
+    parser.add_argument('--preprocess', default=None, choices=[
+            None,
+            'IBDPairConvAe',
+            'IBDPairConvAe2',
+        ],
+        help='preprocess with the given network')
     args = parser.parse_args()
 
+    num_pairs = 10
     if args.file is None:
         infile = ('/project/projectdirs/dasrepo/ibd_pairs/all_pairs.h5')
     else:
         infile = args.file
     if args.input:
         data, _, _ = load_ibd_pairs(infile, train_frac=1, valid_frac = 0,
-            tot_num_pairs=1000)
-        if not args.no_fix_zeros:
-            # Before adjusting values, get rid of zeros in time channels by replacing
-            # them with the average of the neighboring cells
-            smearTimeZeros(data[:1000])
-        if not args.no_preprocess:
-            center(data[:1000])
-            scale(data[:1000], 1)
+            tot_num_pairs=num_pairs)
+        if args.preprocess is not None:
+            conv_class = eval(args.preprocess)
+            cae = conv_class()
+            cae.preprocess_data(data)
     elif args.output:
-        data = load_predictions(infile, tot_num_pairs=1000)
+        data = load_predictions(infile, tot_num_pairs=num_pairs)
 
 
     event = data[args.event]


### PR DESCRIPTION
I assembled a second autoencoder (cleverly named IBDPairConvAe**2**) based on the first one. The only difference is that the input is scaled to lie between +/- 1 and the output is passed through tanh activation so that it too lies between +/- 1. This is the network whose learning rate I am able to train.

I also updated the examine.py visualizer to use the preprocessing algorithm specific to a particular (user-specified) network.
