### PR TITLE
2 updates: new Denoising Autoencoder and "training progress" framework

### DIFF
--- a/ibd_ae.py
+++ b/ibd_ae.py
@@ -71,10 +71,21 @@ if __name__ == "__main__":
     logging.info('Training network')
     epochs = []
     costs = []
-    def saveprogress(epoch, cost):
-        epochs.append(epoch)
-        costs.append(cost)
-    cae.train_loop_hooks.append(saveprogress)
+    def saveprogress(**kwargs):
+        epochs.append(kwargs['epoch'])
+        costs.append(kwargs['cost'])
+    def plotcomparisons(**kwargs):
+        if kwargs['epoch'] % 10 != 0:
+            return
+        plt.subplot(2, 1, 1)
+        plt.imshow(kwargs['input'][0, 0], interpolation='nearest')
+        plt.title('input')
+        plt.subplot(2, 1, 2)
+        plt.imshow(kwargs['output'][0, 0], interpolation='nearest')
+        plt.title('output')
+        plt.savefig('reco%d.pdf' % kwargs['epoch'])
+    cae.epoch_loop_hooks.append(saveprogress)
+    cae.epoch_loop_hooks.append(plotcomparisons)
     cae.fit(train)
 
     plt.plot(epochs, costs)

--- a/ibd_ae.py
+++ b/ibd_ae.py
@@ -13,6 +13,7 @@ from sklearn.decomposition import PCA
 from vis.viz import Viz
 from util.data_loaders import load_ibd_pairs, get_ibd_data
 from networks.LasagneConv import IBDPairConvAe, IBDPairConvAe2
+from networks.LasagneConv import IBDChargeDenoisingConvAe
 import argparse
 import logging
 logging.basicConfig(format='%(levelname)s:\t%(message)s')
@@ -44,6 +45,7 @@ def setup_parser():
         choices=[
             'IBDPairConvAe',
             'IBDPairConvAe2',
+            'IBDChargeDenoisingConvAe',
         ],
         help='network to use')
     return parser
@@ -58,7 +60,9 @@ if __name__ == "__main__":
     cae = convnet_class(bottleneck_width=args.bottleneck_width,
         epochs=args.epochs, learn_rate=args.learn_rate)
     logging.info('Preprocessing data files')
-    train, val, test = get_ibd_data(tot_num_pairs=args.numpairs)
+    only_charge = getattr(cae, 'only_charge', False)
+    train, val, test = get_ibd_data(tot_num_pairs=args.numpairs,
+        just_charges=only_charge)
     preprocess = cae.preprocess_data(train)
     preprocess(val)
     preprocess(test)

--- a/ibd_ae.py
+++ b/ibd_ae.py
@@ -69,13 +69,16 @@ if __name__ == "__main__":
 
     #uses scikit-learn interface (so this trains on X_train)
     logging.info('Training network')
+    epochs = []
+    costs = []
+    def saveprogress(epoch, cost):
+        epochs.append(epoch)
+        costs.append(cost)
+    cae.train_loop_hooks.append(saveprogress)
     cae.fit(train)
 
-    #extract the hidden layer outputs when running x_val thru autoencoder
-    logging.info('Extracting bottleneck layer')
-    feat = cae.extract_layer(val, 'bottleneck')[:, :, 0, 0]
-    logging.debug('feat.shape = %s', str(feat.shape))
-    gr_truth = np.ones(val.shape[0])
+    plt.plot(epochs, costs)
+    plt.savefig('test.pdf')
 
     logging.info('Constructing visualization')
     v = Viz(gr_truth,nclass=1)

--- a/ibd_ae.py
+++ b/ibd_ae.py
@@ -77,19 +77,27 @@ if __name__ == "__main__":
     def plotcomparisons(**kwargs):
         if kwargs['epoch'] % 10 != 0:
             return
-        plt.subplot(2, 1, 1)
-        plt.imshow(kwargs['input'][0, 0], interpolation='nearest')
-        plt.title('input')
-        plt.subplot(2, 1, 2)
-        plt.imshow(kwargs['output'][0, 0], interpolation='nearest')
-        plt.title('output')
-        plt.savefig('reco%d.pdf' % kwargs['epoch'])
+        numevents = 4
+        plotargs = {
+            'interpolation': 'nearest',
+            'aspect': 'auto',
+        }
+        for i in range(numevents):
+            plt.subplot(2, numevents, i + 1)
+            plt.imshow(kwargs['input'][i, 0], **plotargs)
+            plt.title('input %d' % i)
+            plt.subplot(2, numevents, i + numevents + 1)
+            plt.imshow(kwargs['output'][i, 0], **plotargs)
+            plt.title('output %d' % i)
+        plt.savefig('results/progress/reco%d.pdf' % kwargs['epoch'])
+        plt.clf()
     cae.epoch_loop_hooks.append(saveprogress)
     cae.epoch_loop_hooks.append(plotcomparisons)
     cae.fit(train)
 
     plt.plot(epochs, costs)
     plt.savefig('test.pdf')
+    plt.clf()
 
     logging.info('Constructing visualization')
     v = Viz(gr_truth,nclass=1)

--- a/networks/LasagneConv.py
+++ b/networks/LasagneConv.py
@@ -163,6 +163,8 @@ class IBDPairConvAe(AbstractNetwork):
             minibatches = self.minibatch_iterator(x_train)
             for inputs in minibatches():
                 cost = self.train_once(inputs)
+                for fn in self.train_loop_hooks:
+                    fn(epoch, cost)
             logging.info("loss after epoch %d is %f", epoch, cost)
 
     def predict(self, x, y=None):

--- a/networks/LasagneConv.py
+++ b/networks/LasagneConv.py
@@ -41,32 +41,33 @@ class IBDPairConvAe(AbstractNetwork):
 
     def _setup_network(self):
         '''Construct the ConvAe architecture for Daya Bay IBDs.'''
+        num_filters = 128
         initial_weights = l.init.Normal(1.0/self.num_features, 0)
         # Input layer shape = (minibatch_size, 4, 8, 24)
         network = l.layers.InputLayer(
             input_var=self.input_var,
             shape=self.minibatch_shape)
-        # post-conv shape = (minibatch_size, 16, 8, 24)
+        # post-conv shape = (minibatch_size, num_filters, 8, 24)
         network = l.layers.Conv2DLayer(
             network,
-            num_filters=16,
+            num_filters=num_filters,
             filter_size=(5, 5),
             pad=(2, 2),
             W=initial_weights,
             nonlinearity=l.nonlinearities.rectify)
-        # post-pool shape = (minibatch_size, 16, 4, 12)
+        # post-pool shape = (minibatch_size, num_filters, 4, 12)
         network = l.layers.MaxPool2DLayer(
             network,
             pool_size=(2, 2))
-        # post-conv shape = (minibatch_size, 16, 4, 10)
+        # post-conv shape = (minibatch_size, num_filters, 4, 10)
         network = l.layers.Conv2DLayer(
             network,
-            num_filters=16,
+            num_filters=num_filters,
             filter_size=(3, 3),
             pad=(1, 0),
             W=initial_weights,
             nonlinearity=l.nonlinearities.rectify)
-        # post-pool shape = (minibatch_size, 16, 2, 5)
+        # post-pool shape = (minibatch_size, num_filters, 2, 5)
         network = l.layers.MaxPool2DLayer(
             network,
             pool_size=(2, 2))
@@ -79,17 +80,17 @@ class IBDPairConvAe(AbstractNetwork):
             pad=0,
             W=initial_weights,
             nonlinearity=l.nonlinearities.rectify)
-        # post-deconv shape = (minibatch_size, 16, 2, 4)
+        # post-deconv shape = (minibatch_size, num_filters, 2, 4)
         network = l.layers.Deconv2DLayer(
             network,
-            num_filters=16,
+            num_filters=num_filters,
             filter_size=(2, 4),
             stride=(2, 2),
             W=initial_weights)
-        # post-deconv shape = (minibatch_size, 16, 4, 11)
+        # post-deconv shape = (minibatch_size, num_filters, 4, 11)
         network = l.layers.Deconv2DLayer(
             network,
-            num_filters=16,
+            num_filters=num_filters,
             filter_size=(2, 5),
             stride=(2, 2),
             W=initial_weights)

--- a/networks/Network.py
+++ b/networks/Network.py
@@ -14,7 +14,18 @@ class AbstractNetwork(object):
         self.train_cost = None
         self.test_cost = None
         self.optimizer = None
-        self.train_loop_hooks = []
+        self.epoch_loop_hooks = []
+        '''This list of functions is called after each epoch is run.
+        
+           The functions will be called in the order they appear in the list.
+           Each function should have a signature of (**kwargs). The provided
+           arguments will be included:
+           
+             - 'cost': the cost
+             - 'epoch': the epoch number
+             - 'input': the input minibatch
+             - 'output': the reconstructed minibatch
+        '''
 
     def fit(self, x_train, y_train):
         '''train network'''

--- a/networks/Network.py
+++ b/networks/Network.py
@@ -14,6 +14,7 @@ class AbstractNetwork(object):
         self.train_cost = None
         self.test_cost = None
         self.optimizer = None
+        self.train_loop_hooks = []
 
     def fit(self, x_train, y_train):
         '''train network'''

--- a/util/data_loaders.py
+++ b/util/data_loaders.py
@@ -6,7 +6,6 @@ import pickle
 import glob
 import os
 from operator import mul
-from networks.preprocessing import scale, scale_min_max
 def load_ibd_pairs(path, train_frac=0.5, valid_frac=0.25, tot_num_pairs=-1):
     '''Load up the hdf5 file given into a set of numpy arrays suitable for
     convnets.
@@ -53,6 +52,7 @@ def get_ibd_data(path_prefix="/project/projectdirs/dasrepo/ibd_pairs", preproces
         val = val[:,[0,2]]
         test = test[:,[0,2]]
     if preprocess:
+        from networks.preprocessing import scale, scale_min_max
         if mode == 'normalize':
             mins, maxes = scale_min_max(train)
             scale_min_max(test,mins=mins,maxes=maxes)

--- a/vis/examine.py
+++ b/vis/examine.py
@@ -22,6 +22,8 @@ if __name__ == '__main__':
         help='interpret the file as input')
     gp.add_argument('-o', '--output', action='store_true',
         help='interpret the file as output')
+    parser.add_argument('--flex-color', action='store_true',
+        help='use a variable color scale per plot')
     parser.add_argument('--preprocess', default=None, choices=[
             None,
             'IBDPairConvAe',
@@ -53,6 +55,11 @@ if __name__ == '__main__':
         'aspect': 'auto',
         'cmap': plt.get_cmap('PuBu')
     }
+    if not args.flex_color:
+        image_args.update({
+            'vmin': -1,
+            'vmax': 1,
+        })
     fig = plt.figure(1)
     prompt_charge_ax = plt.subplot(2, 2, 1)
     prompt_charge_im = plt.imshow(event[0], **image_args)

--- a/vis/examine.py
+++ b/vis/examine.py
@@ -11,6 +11,7 @@ sys.path.append(os.path.abspath('../util'))
 sys.path.append(os.path.abspath('../networks'))
 from data_loaders import load_ibd_pairs, load_predictions
 from LasagneConv import IBDPairConvAe, IBDPairConvAe2
+from LasagneConv import IBDChargeDenoisingConvAe
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
@@ -28,6 +29,7 @@ if __name__ == '__main__':
             None,
             'IBDPairConvAe',
             'IBDPairConvAe2',
+            'IBDChargeDenoisingConvAe',
         ],
         help='preprocess with the given network')
     args = parser.parse_args()


### PR DESCRIPTION
The denoising autoencoder is based on the same architecture as the earlier CAEs. It has 2 differences:
1. it only takes in prompt and delayed charge, not time.
2. it is a denoising autoencoder, so it corrupts input and tries to reconstruct it.

I also increased the number of filters on the original IBDPairConvAe from 16 to 128.

The training progress framework is simple: the AbstractNetwork base class has an extra attribute, which is a list of functions (default = empty). At the end of each epoch, the list of functions gets iterated, and each function is called with a specified standard set of arguments. The epoch number is also provided, in case the user wants to skip certain epochs.

The utility of this framework is that the user can specify status/progress messages to print, _without messing with the internals of the training loop code_. The functions are defined in the "main" code rather than the class code.

This is how I made my training cost graph and my reconstruction plots.
