### PR TITLE
Small updates to my networks and the data_loaders interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.pyc
 *.swp
 *.h5
+*.pdf
 results
 # Ignore everything in batch log and tmp except for .gitkeep
 batch/logs/*

--- a/batch/run_ibd_ae.py.sh
+++ b/batch/run_ibd_ae.py.sh
@@ -5,10 +5,10 @@ echo "Finished sourceing setup file"
 echo "Start seconds"
 date +%s
 echo "---"
-python $SLURM_SUBMIT_DIR/ibd_ae.py -e 100 -w 256 \
--s model_e100_w256_n200.npz \
--p reco_e100_w256_n200.h5 \
--l 0.01 -n 200 -vvv --network IBDChargeDenoisingConvAe \
+python $SLURM_SUBMIT_DIR/ibd_ae.py -e 10 -w 256 \
+-s model_e10_w256_n20000.npz \
+-p reco_e10_w256_n20000.h5 \
+-l 0.01 -n 20000 -vvv --network IBDChargeDenoisingConvAe \
 --out-dir $SLURM_SUBMIT_DIR/batch/tmp_output
 echo "End seconds"
 date +%s

--- a/batch/submit_ibd_ae.py.sl
+++ b/batch/submit_ibd_ae.py.sl
@@ -3,9 +3,9 @@
 # This script will submit a NN training job to the "shared" partition where 1
 # core can be requested
 
-#SBATCH -p debug
+#SBATCH -p regular
 #SBATCH -N 1
-#SBATCH -t 00:05:00
+#SBATCH -t 00:15:00
 #SBATCH -J train_dca
 #SBATCH -A dasrepo
 #SBATCH -L project

--- a/networks/LasagneConv.py
+++ b/networks/LasagneConv.py
@@ -44,10 +44,12 @@ class IBDPairConvAe(AbstractNetwork):
         # Input layer shape = (minibatch_size, 4, 8, 24)
         network = l.layers.InputLayer(
             input_var=self.input_var,
+            name='input',
             shape=self.minibatch_shape)
         # post-conv shape = (minibatch_size, num_filters, 8, 24)
         network = l.layers.Conv2DLayer(
             network,
+            name='conv1',
             num_filters=num_filters,
             filter_size=(5, 5),
             pad=(2, 2),
@@ -56,10 +58,12 @@ class IBDPairConvAe(AbstractNetwork):
         # post-pool shape = (minibatch_size, num_filters, 4, 12)
         network = l.layers.MaxPool2DLayer(
             network,
+            name='pool1',
             pool_size=(2, 2))
         # post-conv shape = (minibatch_size, num_filters, 4, 10)
         network = l.layers.Conv2DLayer(
             network,
+            name='conv2',
             num_filters=num_filters,
             filter_size=(3, 3),
             pad=(1, 0),
@@ -68,6 +72,7 @@ class IBDPairConvAe(AbstractNetwork):
         # post-pool shape = (minibatch_size, num_filters, 2, 5)
         network = l.layers.MaxPool2DLayer(
             network,
+            name='pool2',
             pool_size=(2, 2))
         # post-conv shape = (minibatch_size, bottleneck_width, 1, 1)
         network = l.layers.Conv2DLayer(
@@ -81,6 +86,7 @@ class IBDPairConvAe(AbstractNetwork):
         # post-deconv shape = (minibatch_size, num_filters, 2, 4)
         network = l.layers.Deconv2DLayer(
             network,
+            name='deconv1',
             num_filters=num_filters,
             filter_size=(2, 4),
             stride=(2, 2),
@@ -88,6 +94,7 @@ class IBDPairConvAe(AbstractNetwork):
         # post-deconv shape = (minibatch_size, num_filters, 4, 11)
         network = l.layers.Deconv2DLayer(
             network,
+            name='deconv2',
             num_filters=num_filters,
             filter_size=(2, 5),
             stride=(2, 2),
@@ -95,6 +102,7 @@ class IBDPairConvAe(AbstractNetwork):
         # post-deconv shape = (minibatch_size, input_depth, 8, 24)
         network = l.layers.Deconv2DLayer(
             network,
+            name='deconv3',
             num_filters=self.image_shape[0],
             filter_size=(2, 4),
             stride=(2, 2),

--- a/networks/LasagneConv.py
+++ b/networks/LasagneConv.py
@@ -193,14 +193,21 @@ class IBDPairConvAe(AbstractNetwork):
 
     def extract_layer(self, data, layer):
         '''Extract the output of the given layer.'''
+        lasagne_layer = self._get_layer_named(layer)
+        output = l.layers.get_output(lasagne_layer)
+        out_fn = theano.function([self.input_var], output)
+        return out_fn(data)
+
+    def _get_layer_named(self, name):
+        '''Get the Lasagne layer object with the given name located in
+        self.network.'''
+
         all_layers = l.layers.get_all_layers(self.network)
-        # find the layer named with the value of layer
         for one_layer in all_layers:
-            if one_layer.name == layer:
-                output = l.layers.get_output(one_layer)
-                out_fn = theano.function([self.input_var], output)
-                return out_fn(data)
-        raise ValueError('"%s" is not a layer in our network' % layer)
+            if one_layer.name == name:
+                return one_layer
+        raise ValueError('"%s" is not a layer in our network' % name)
+
 
     def preprocess_data(self, x, y=None):
         '''Prepare the data for the neural network.

--- a/networks/LasagneConv.py
+++ b/networks/LasagneConv.py
@@ -39,13 +39,20 @@ class IBDPairConvAe(AbstractNetwork):
 
     def _setup_network(self):
         '''Construct the ConvAe architecture for Daya Bay IBDs.'''
-        num_filters = 128
-        initial_weights = l.init.Normal(1.0/self.num_features, 0)
         # Input layer shape = (minibatch_size, 4, 8, 24)
         network = l.layers.InputLayer(
             input_var=self.input_var,
             name='input',
             shape=self.minibatch_shape)
+        network = self._default_network_with_input(network)
+        return network
+
+    def _default_network_with_input(self, incoming):
+        '''Add on the default/standard conv/bottleneck/deconv layers to the
+        specified incoming network'''
+        num_filters = 128
+        initial_weights = l.init.Normal(1.0/self.num_features, 0)
+        network = incoming
         # post-conv shape = (minibatch_size, num_filters, 8, 24)
         network = l.layers.Conv2DLayer(
             network,

--- a/networks/README.md
+++ b/networks/README.md
@@ -31,13 +31,13 @@ performed, etc.
       channel's standard deviation (over all events) is 1
  - Layers:
     - Convolutional layer:
-        - 16 filters
+        - 128 filters
         - (5, 5) filter size
         - (2, 2) padding
         - ReLU activation
     - Max pool layer: (2, 2) pool size
     - Convolutional layer:
-        - 16 filters
+        - 128 filters
         - (3, 3) filter size
         - (1, 0) padding
         - ReLU activation
@@ -48,11 +48,11 @@ performed, etc.
         - (0, 0) padding
         - ReLU activation
     - Deconvolutional layer:
-        - 16 filters
+        - 128 filters
         - (2, 4) filter size
         - (2, 2) stride
     - Deconvolutional layer:
-        - 16 filters
+        - 128 filters
         - (2, 5) filter size
         - (2, 2) stride
     - Deconvolutional layer:

--- a/util/data_loaders.py
+++ b/util/data_loaders.py
@@ -42,10 +42,13 @@ def load_ibd_pairs(path, train_frac=0.5, valid_frac=0.25, tot_num_pairs=-1):
 
 
 def get_ibd_data(path_prefix="/project/projectdirs/dasrepo/ibd_pairs", preprocess=False, mode='normalize',
-                tot_num_pairs=-1, just_charges=False):
+                tot_num_pairs=-1, just_charges=False, train_frac=0.5,
+                valid_frac=0.25):
     
     h5filename = "all_pairs.h5"
-    train, val, test = load_ibd_pairs(path=os.path.join(path_prefix, h5filename), tot_num_pairs=tot_num_pairs)
+    train, val, test = load_ibd_pairs(path=os.path.join(path_prefix,
+        h5filename), tot_num_pairs=tot_num_pairs, train_frac=train_frac,
+        valid_frac=valid_frac)
     #would be nice to optionally preprocess upon loading (mostly for unit testing)
     if just_charges:
         train = train[:,[0,2]]


### PR DESCRIPTION
I fixed some issues with my networks, including using the simpler dropout to corrupt the input to the denoising autoencoder. I also updated my batch scripts a little, and allowed the user to specify what fraction of the events should be returned as train, val, and test in the `get_ibd_pairs` method of data_loaders.py.
